### PR TITLE
Workaround for performDragOperation: not being called

### DIFF
--- a/ImageReducer/ImageDropView.m
+++ b/ImageReducer/ImageDropView.m
@@ -81,4 +81,14 @@
     return anyFileValid;
 }
 
+// Workaround for the case when performDragOperation: is not called
+// see http://stackoverflow.com/a/12795637
+- (void)draggingEnded:(id<NSDraggingInfo>)sender
+{
+    if(NSPointInRect([sender draggingLocation],self.frame)){
+        //The file was actually dropped on the view so call the performDrag manually
+        [self performDragOperation:sender];
+    }
+}
+
 @end


### PR DESCRIPTION
Fixes problems with drag&drop - issue #3 
Inspired by: http://stackoverflow.com/questions/8250203/performdragoperation-not-called-when-dragging-from-dock-stack
